### PR TITLE
Remove space between macro names and parenthesis

### DIFF
--- a/src/parse/config.jl
+++ b/src/parse/config.jl
@@ -27,7 +27,7 @@ triggers(f) = get(meta(f), :triggers, Set{Char}())
 isexpr(x::Expr, ts...) = x.head in ts
 isexpr{T}(x::T, ts...) = T in ts
 
-macro breaking (ex)
+macro breaking(ex)
     isexpr(ex, :->) || error("invalid @breaking form, use ->")
     b, def = ex.args
     if b
@@ -41,7 +41,7 @@ macro breaking (ex)
     end
 end
 
-macro trigger (ex)
+macro trigger(ex)
     isexpr(ex, :->) || error("invalid @triggers form, use ->")
     ts, def = ex.args
     quote
@@ -74,7 +74,7 @@ end
 
 const flavors = Dict{Symbol, Config}()
 
-macro flavor (name, features)
+macro flavor(name, features)
     quote
         const $(esc(name)) = config($(map(esc,features.args)...))
         flavors[$(Expr(:quote, name))] = $(esc(name))


### PR DESCRIPTION
As suggested by julia's warnings:

"breaking (ex)" -> "breaking(ex)"
"trigger (ex)" -> "trigger(ex)"
"flavor (ex)" -> "flavor(ex)"